### PR TITLE
chore: fix event decoding, disable scroll webview behaviour

### DIFF
--- a/Sources/KontextSwiftSDK/Networking/DTO/EventIframeDataDTO.swift
+++ b/Sources/KontextSwiftSDK/Networking/DTO/EventIframeDataDTO.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct EventIframeContentDTO: Decodable, Hashable {
+struct EventIframeDataDTO: Decodable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case name
         case code

--- a/Sources/KontextSwiftSDK/Networking/DTO/IframeEventDTO.swift
+++ b/Sources/KontextSwiftSDK/Networking/DTO/IframeEventDTO.swift
@@ -102,12 +102,6 @@ extension IframeEvent {
     struct UnknownDataDTO: Decodable, Hashable {
         let type: String
     }
-
-    /// Data for iframe event
-    struct EventIframeDataDTO: Decodable, Hashable {
-        let type: String
-        let data: EventIframeContentDTO
-    }
 }
 
 // MARK: - Event Parsing

--- a/Sources/KontextSwiftSDK/Networking/Mapping/IframeEvent+Mapping.swift
+++ b/Sources/KontextSwiftSDK/Networking/Mapping/IframeEvent+Mapping.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-extension IframeEvent.EventIframeDataDTO: ModelConvertible {
+extension EventIframeDataDTO: ModelConvertible {
     func toModel() -> AdsEvent {
-        data.type.toModel()
+        type.toModel()
     }
 }
 
-extension EventIframeContentDTO.TypeDTO: ModelConvertible {
+extension EventIframeDataDTO.TypeDTO: ModelConvertible {
     func toModel() -> AdsEvent {
         switch self {
         case .viewed(let viewedDataDTO):
@@ -31,7 +31,7 @@ extension EventIframeContentDTO.TypeDTO: ModelConvertible {
     }
 }
 
-extension EventIframeContentDTO.ViewedDataDTO: ModelConvertible {
+extension EventIframeDataDTO.ViewedDataDTO: ModelConvertible {
     func toModel() -> AdsEvent.ViewedData {
         AdsEvent.ViewedData(
             bidId: id,
@@ -41,7 +41,7 @@ extension EventIframeContentDTO.ViewedDataDTO: ModelConvertible {
     }
 }
 
-extension EventIframeContentDTO.ClickedDataDTO: ModelConvertible {
+extension EventIframeDataDTO.ClickedDataDTO: ModelConvertible {
     func toModel() -> AdsEvent.ClickedData {
         AdsEvent.ClickedData(
             bidId: id,
@@ -52,7 +52,7 @@ extension EventIframeContentDTO.ClickedDataDTO: ModelConvertible {
     }
 }
 
-extension EventIframeContentDTO.ErrorDataDTO: ModelConvertible {
+extension EventIframeDataDTO.ErrorDataDTO: ModelConvertible {
     func toModel() -> AdsEvent.ErrorData {
         AdsEvent.ErrorData(
             message: message,
@@ -61,7 +61,7 @@ extension EventIframeContentDTO.ErrorDataDTO: ModelConvertible {
     }
 }
 
-extension EventIframeContentDTO.GeneralDataDTO: ModelConvertible {
+extension EventIframeDataDTO.GeneralDataDTO: ModelConvertible {
     func toModel() -> AdsEvent.GeneralData {
         AdsEvent.GeneralData(bidId: id)
     }

--- a/Sources/KontextSwiftSDK/WebView/AdWebView.swift
+++ b/Sources/KontextSwiftSDK/WebView/AdWebView.swift
@@ -51,6 +51,7 @@ final class AdWebView: WKWebView {
 
         isOpaque = false
         backgroundColor = .clear
+        scrollView.isScrollEnabled = false
 
         scriptHandler = AdScriptMessageHandler(adWebView: self)
         if let scriptHandler {

--- a/Tests/KontextAdsTests/AdsEventTests.swift
+++ b/Tests/KontextAdsTests/AdsEventTests.swift
@@ -9,28 +9,25 @@ struct AdsEventTests {
     func testKnownEventWithData() async throws {
         let json = """
             {
-              "type": "event-iframe",
-              "data": {
                 "name": "ad.clicked",
                 "code": "200",
                 "payload": { 
                    "id": "uuid",
                    "content": "black",
                    "messageId": "1234"
-                }
-              }
+                }              
             }
         """
 
         let data = try #require(json.data(using: .utf8))
-        let result = try JSONDecoder().decode(IframeEvent.EventIframeDataDTO.self, from: data)
+        let result = try JSONDecoder().decode(EventIframeDataDTO.self, from: data)
 
-        #expect(result.data.name == "ad.clicked")
+        #expect(result.name == "ad.clicked")
 
-        switch result.data.type {
+        switch result.type {
         case .clicked(let data):
             #expect(
-                data == EventIframeContentDTO.ClickedDataDTO(
+                data == EventIframeDataDTO.ClickedDataDTO(
                     id: "uuid",
                     content: "black",
                     messageId: "1234",
@@ -38,7 +35,7 @@ struct AdsEventTests {
                 )
             )
         default:
-            Issue.record("Expected clicked event type, got: \(result.data.type)")
+            Issue.record("Expected clicked event type, got: \(result.type)")
         }
     }
 
@@ -46,24 +43,21 @@ struct AdsEventTests {
     func testKnownEventWithMissingData() async throws {
         let json = """
             {
-              "type": "event-iframe",
-              "data": {
                 "name": "ad.clicked",
-                "code": "200"
-              }
+                "code": "200"              
             }
         """
 
         let data = try #require(json.data(using: .utf8))
-        let result = try JSONDecoder().decode(IframeEvent.EventIframeDataDTO.self, from: data)
+        let result = try JSONDecoder().decode(EventIframeDataDTO.self, from: data)
 
-        #expect(result.data.name == "ad.clicked")
+        #expect(result.name == "ad.clicked")
 
-        switch result.data.type {
+        switch result.type {
         case .clicked(let data):
             #expect(data == nil)
         default:
-            Issue.record("Expected clicked event type, got: \(result.data.type)")
+            Issue.record("Expected clicked event type, got: \(result.type)")
         }
     }
 
@@ -71,28 +65,25 @@ struct AdsEventTests {
     func testKnownEventWithUnknownEvent() async throws {
         let json = """
             {
-              "type": "event-iframe",
-              "data": {
                 "name": "new-event",
                 "code": "200",
                 "payload": {
                    "videoId": 1000
-                }
-              }
+                }              
             }
         """
 
         let data = try #require(json.data(using: .utf8))
-        let result = try JSONDecoder().decode(IframeEvent.EventIframeDataDTO.self, from: data)
+        let result = try JSONDecoder().decode(EventIframeDataDTO.self, from: data)
 
-        #expect(result.data.name == "new-event")
+        #expect(result.name == "new-event")
 
-        switch result.data.type {
+        switch result.type {
         case .event(let data):
             let value = data["videoId"]?.value as? Int
             #expect(value == 1000)
         default:
-            Issue.record("Expected clicked event type, got: \(result.data.type)")
+            Issue.record("Expected clicked event type, got: \(result.type)")
         }
     }
 }


### PR DESCRIPTION
* fix ad event decoding
* disable scrollview in webview - might help with sizing issue but maybe not, either way it'll be safer to assume there's no scrollable ad content so the size reported only concerns the ad size