### PR TITLE
Update release version in changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ List of changes by respective version.
 
 ## [1.1.1](https://github.com//kontextso/sdk-swift/releases/tag/1.1.1)
 
+Released on 2025-09-10.
+
 ### Removed
 
 - Removed predefined debugging messages from Example apps.


### PR DESCRIPTION
Supply date of release 1.1.1 that was left out.