### PR TITLE
Prepare release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 List of changes by respective version.
 
+## [1.2.0](https://github.com//kontextso/sdk-swift/releases/tag/1.2.0)
+
+Released on 2025-10-02.
+
+## Fixed
+
+- Always send ad.no-fill event when ads are not avilable.
+
 > This lists was started with version 1.1.0 and therefore no previous changes are listed here.
 
 ## [1.1.5](https://github.com//kontextso/sdk-swift/releases/tag/1.1.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+> This lists was started with version 1.1.0 and therefore no previous changes are listed here.
+
 List of changes by respective version.
 
 ## [1.2.0](https://github.com//kontextso/sdk-swift/releases/tag/1.2.0)
@@ -9,8 +11,6 @@ Released on 2025-10-02.
 ## Fixed
 
 - Always send ad.no-fill event when ads are not avilable.
-
-> This lists was started with version 1.1.0 and therefore no previous changes are listed here.
 
 ## [1.1.5](https://github.com//kontextso/sdk-swift/releases/tag/1.1.5)
 

--- a/KontextSwiftSDK.podspec
+++ b/KontextSwiftSDK.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |spec|
     spec.name                 = 'KontextSwiftSDK'
-    spec.version              = '1.1.5'
+    spec.version              = '1.2.0'
     spec.summary              = 'Kontext.so Swift SDK'
     spec.description          = <<-DESC
     The official Swift SDK for integrating Kontext.so ads into your mobile application.

--- a/Sources/KontextSwiftSDK/Model/Info/SDKInfo.swift
+++ b/Sources/KontextSwiftSDK/Model/Info/SDKInfo.swift
@@ -4,7 +4,7 @@ import UIKit
 struct SDKInfo  {
     static let defaultAdServerURL: URL = URL(string: "https://server.megabrain.co")!
     static let sdkName = "sdk-swift"
-    static let sdkVersion = "1.1.4"
+    static let sdkVersion = "1.2.0"
 
     /// Name of the SDK's bundle, should be sdk-swift
     let name: String


### PR DESCRIPTION
## [1.2.0](https://github.com//kontextso/sdk-swift/releases/tag/1.2.0)

Released on 2025-10-02.

## Fixed

- Always send ad.no-fill event when ads are not avilable.