### PR TITLE
Fix crash when WKScriptMessage body is not a valid JSON object

### DIFF
--- a/Sources/KontextSwiftSDK/Extensions/Codable+JSON.swift
+++ b/Sources/KontextSwiftSDK/Extensions/Codable+JSON.swift
@@ -16,6 +16,14 @@ extension Encodable {
 
 extension Decodable {
     init(fromJSON json: Any) throws {
+        guard JSONSerialization.isValidJSONObject(json) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "Invalid JSON object: \(type(of: json)) is not serializable"
+                )
+            )
+        }
         let data = try JSONSerialization.data(withJSONObject: json, options: [])
         self = try JSONDecoder().decode(Self.self, from: data)
     }

--- a/Tests/KontextAdsTests/Extensions/CodableJSONTests.swift
+++ b/Tests/KontextAdsTests/Extensions/CodableJSONTests.swift
@@ -38,6 +38,13 @@ struct CodableJSONTests {
     }
 
     @Test
+    func decodeFromJSONThrowsForInvalidJSONObject() throws {
+        #expect(throws: DecodingError.self) {
+            try Person(fromJSON: "just a string")
+        }
+    }
+
+    @Test
     func roundtrip() throws {
         let original = Person(name: "Charlie", age: 40)
         let json = try original.encodeToJSON()


### PR DESCRIPTION
## Summary
- Fixes a crash in `AdScriptMessageHandler.userContentController(_:didReceive:)` reported by a customer on SDK v2.1
- `JSONSerialization.data(withJSONObject:)` throws an **Objective-C NSException** (not a Swift error) when the WKScriptMessage body is a non-serializable type (e.g. a plain `String`). Swift `try/catch` cannot catch NSExceptions, so this causes an unrecoverable crash
- The WebView's `message` listener captures **all** `postMessage` events in the page, including from third-party ad creatives which may post non-object values
- Added `JSONSerialization.isValidJSONObject()` guard to throw a catchable Swift `DecodingError` instead

## Test plan
- [ ] Added unit test for invalid JSON object input (`decodeFromJSONThrowsForInvalidJSONObject`)
- [ ] Verify existing `CodableJSONTests` pass
- [ ] Test with ad creative that posts a raw string via `postMessage` — should log error instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)