### PR TITLE
Activate AVAudioSession for OMID video ads to enable volume change events

### DIFF
--- a/Sources/KontextSwiftSDK/AdsProviderActor.swift
+++ b/Sources/KontextSwiftSDK/AdsProviderActor.swift
@@ -127,6 +127,7 @@ extension AdsProviderActor: AdsProviderActing {
                     os_log("[\(ts)] [OMID] Session finished (\(state.creativeType.rawValue)) for stateId: \(state.stateId)")
                 }
             }
+            deactivateAudioSessionIfNeeded()
             await reset()
             notifyAdsCleared()
         } else {

--- a/Sources/KontextSwiftSDK/AdsProviderActor.swift
+++ b/Sources/KontextSwiftSDK/AdsProviderActor.swift
@@ -43,6 +43,7 @@ actor AdsProviderActor {
     private let skStoreProductPresenter: any SKStoreProductPresenting
     private weak var delegate: AdsProviderActingDelegate?
     private var skanOwner: (stateId: UUID, bidId: UUID)?
+    private let omAudioSessionHelper = OMAudioSessionHelper()
 
     // stateId waiting for start after init
     private var pendingStart: UUID?
@@ -126,6 +127,7 @@ extension AdsProviderActor: AdsProviderActing {
                     os_log("[\(ts)] [OMID] Session finished (\(state.creativeType.rawValue)) for stateId: \(state.stateId)")
                 }
             }
+            deactivateAudioSessionIfNeeded()
             await reset()
             notifyAdsCleared()
         } else {
@@ -230,6 +232,7 @@ extension AdsProviderActor: AdsProviderActing {
                 os_log("[\(ts)] [OMID] Session finished in reset (\(state.creativeType.rawValue)) for stateId: \(state.stateId)")
             }
         }
+        deactivateAudioSessionIfNeeded()
         bids = []
         states = []
     }
@@ -545,6 +548,7 @@ private extension AdsProviderActor {
             state.session.finish()
         }
         os_log("[\(ts)] [OMID] Session finished (\(state.creativeType.rawValue)) for stateId: \(stateId)")
+        deactivateAudioSessionIfNeeded()
         try? await Task.sleep(seconds: 1)
     }
 
@@ -628,6 +632,7 @@ private extension AdsProviderActor {
                 existingSession.finish()
             }
             omSessions.remove(at: existingIndex)
+            deactivateAudioSessionIfNeeded()
             return
         }
 
@@ -654,6 +659,11 @@ private extension AdsProviderActor {
 
     func startOMSession(webView: WKWebView, url: URL?, stateId: UUID, creativeType: OmCreativeType) async {
         do {
+            // Activate audio session for video ads so the OMID SDK can detect device volume changes.
+            if creativeType == .video {
+                await MainActor.run { omAudioSessionHelper.activate() }
+            }
+
             let omSession = try await MainActor.run {
                 let session = try omService.createSession(webView, url: url, creativeType: creativeType)
                 session.start()
@@ -663,6 +673,15 @@ private extension AdsProviderActor {
             omSessions.append(newState)
         } catch {
             os_log("OM failed to start: \(String(describing: error))")
+            deactivateAudioSessionIfNeeded()
+        }
+    }
+
+    /// Deactivates the audio session when no video OM sessions remain.
+    private func deactivateAudioSessionIfNeeded() {
+        let hasVideoSessions = omSessions.contains(where: { $0.creativeType == .video })
+        if !hasVideoSessions {
+            Task { @MainActor in omAudioSessionHelper.deactivate() }
         }
     }
 }

--- a/Sources/KontextSwiftSDK/AdsProviderActor.swift
+++ b/Sources/KontextSwiftSDK/AdsProviderActor.swift
@@ -127,7 +127,6 @@ extension AdsProviderActor: AdsProviderActing {
                     os_log("[\(ts)] [OMID] Session finished (\(state.creativeType.rawValue)) for stateId: \(state.stateId)")
                 }
             }
-            deactivateAudioSessionIfNeeded()
             await reset()
             notifyAdsCleared()
         } else {

--- a/Sources/KontextSwiftSDK/OMSDK/OMAudioSessionHelper.swift
+++ b/Sources/KontextSwiftSDK/OMSDK/OMAudioSessionHelper.swift
@@ -1,0 +1,43 @@
+import AVFAudio
+import OSLog
+
+/// Manages AVAudioSession for OMID device volume change tracking in HTML video ads.
+///
+/// The OMID native SDK automatically detects device volume changes, but requires
+/// an active audio session with `.mixWithOthers` to observe `outputVolume` via KVO.
+/// Without this, device volume change events are not delivered to verification scripts.
+///
+/// Reference: IAB OMSDK demo WebViewVideoController.swift
+@MainActor
+final class OMAudioSessionHelper {
+    private var isActive = false
+
+    /// Activates the audio session so the OMID SDK can observe device volume changes.
+    /// Idempotent — calling multiple times has no effect.
+    func activate() {
+        guard !isActive else { return }
+
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playback, mode: .default, options: .mixWithOthers)
+            try session.setActive(true)
+            isActive = true
+        } catch {
+            os_log(.error, "[OM] Failed to activate audio session: \(error)")
+        }
+    }
+
+    /// Deactivates the audio session.
+    func deactivate() {
+        guard isActive else { return }
+
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            os_log(.error, "[OM] Failed to deactivate audio session: \(error)")
+        }
+
+        isActive = false
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes IAB certification issue: "device volume change events are not working for HTML Video Ads"
- The OMID SDK automatically detects device volume changes via KVO on `AVAudioSession.outputVolume`, but requires an active audio session with `.mixWithOthers` for the observer to fire
- Added `OMAudioSessionHelper` that activates/deactivates the audio session around video OM sessions, following the [IAB OMSDK demo](https://github.com/nicholashills/omsdk-ios/blob/master/OM-Demo/WebViewVideoController.swift) pattern
- Confirmed no background music interruption when ads render (`.mixWithOthers` mixes alongside existing audio)

## Note
- `outputVolume` KVO does **not** fire on the iOS Simulator — must be tested on a physical device
- `setActive(false)` is called when no video sessions remain; no ~1s audio pause was observed in testing

## Test plan
- [x] Tested on physical device — device volume change events now appear in OMID session data
- [x] Background music plays uninterrupted when ads render
- [x] Run IAB OMID validation tool to confirm `deviceVolume` field in `volumeChange` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)