### PR TITLE
Fix ad.render-started / ad.render-completed event names

### DIFF
--- a/Sources/KontextSwiftSDK/Networking/DTO/EventIframeDataDTO.swift
+++ b/Sources/KontextSwiftSDK/Networking/DTO/EventIframeDataDTO.swift
@@ -14,8 +14,8 @@ struct EventIframeDataDTO: Decodable, Hashable {
     enum TypeName: String {
         case viewed = "ad.viewed"
         case clicked = "ad.clicked"
-        case renderStarted = "ad.renderStarted"
-        case renderCompleted = "ad.render"
+        case renderStarted = "ad.render-started"
+        case renderCompleted = "ad.render-completed"
         case error = "ad.error"
         case rewardGranted = "reward.granted"
         case videoStarted = "video.started"

--- a/Tests/KontextAdsTests/Networking/Mapping/IframeEventMappingTests.swift
+++ b/Tests/KontextAdsTests/Networking/Mapping/IframeEventMappingTests.swift
@@ -146,6 +146,34 @@ struct IframeEventMappingTests {
 
     // MARK: - EventIframeDataDTO wrapper
 
+    // MARK: - JSON decoding (webview → DTO)
+
+    /// The webview emits event names that must match `TypeName` raw values exactly.
+    /// If they drift, `init(from:)` silently falls through to `.event(dictionary)`.
+    @Test
+    func decodesKnownEventNamesToTypedCases() throws {
+        func decode(_ json: String) throws -> EventIframeDataDTO {
+            try JSONDecoder().decode(EventIframeDataDTO.self, from: Data(json.utf8))
+        }
+
+        let bidId = UUID().uuidString
+        let generalPayload = #"{"id":"\#(bidId)"}"#
+
+        let renderStarted = try decode(#"{"name":"ad.render-started","code":"inlineAd","payload":\#(generalPayload)}"#)
+        if case .renderStarted(let p) = renderStarted.type { #expect(p?.id == UUID(uuidString: bidId)) }
+        else { Issue.record("render-started decoded as \(renderStarted.type)") }
+
+        let renderCompleted = try decode(#"{"name":"ad.render-completed","code":"inlineAd","payload":\#(generalPayload)}"#)
+        if case .renderCompleted(let p) = renderCompleted.type { #expect(p?.id == UUID(uuidString: bidId)) }
+        else { Issue.record("render-completed decoded as \(renderCompleted.type)") }
+
+        let viewed = try decode(#"{"name":"ad.viewed","code":"inlineAd","payload":{"id":"\#(bidId)","content":"c","messageId":"m"}}"#)
+        if case .viewed = viewed.type {} else { Issue.record("viewed decoded as \(viewed.type)") }
+
+        let unknown = try decode(#"{"name":"ad.something-new","code":"inlineAd","payload":{"foo":"bar"}}"#)
+        if case .event = unknown.type {} else { Issue.record("unknown decoded as \(unknown.type)") }
+    }
+
     @Test
     func eventIframeDataDTOToModelDelegatesToTypeDTO() {
         let dto = EventIframeDataDTO(


### PR DESCRIPTION
## Summary

- `EventIframeDataDTO.TypeName` had `ad.renderStarted` and `ad.render` as raw values, but the webview actually emits `ad.render-started` and `ad.render-completed` per the public docs at https://docs.kontext.so/sdk/ios.
- Because the raw strings didn't match, `EventIframeDataDTO.init(from:)` silently fell through to the generic `.event(dictionary)` case. The test app subscribed to typed render events never saw them — it only caught them as generic `ad.event` payloads.
- Fixes the raw values to match the docs and adds a decoding test that pins the wire names so this can't drift again unnoticed.

## Test plan

- [x] `swift test --filter IframeEventMappingTests` passes, including the new `decodesKnownEventNamesToTypedCases` case.
- [ ] Verify in the test app that `renderStarted` and `renderCompleted` events are now surfaced as their typed cases instead of `event`.