### PR TITLE
Release version 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.1
+* Fix crash in `AdScriptMessageHandler` when `WKScriptMessage.body` is not a valid JSON top-level object (e.g. a raw `String` posted by a third-party ad creative). `JSONSerialization.data(withJSONObject:)` was raising an Objective-C `NSException` that Swift `try/catch` could not catch; the bridge now validates with `JSONSerialization.isValidJSONObject` first and throws a catchable `DecodingError` instead.
+
 ## 2.1.0
 * Add `requestTrackingAuthorization` option to `AdsProviderConfiguration` — set to `false` to suppress the SDK's ATT prompt and manage it yourself.
 * Fix manually supplied `advertisingId`/`vendorId` now correctly take priority over automatically collected values.

--- a/KontextSwiftSDK.podspec
+++ b/KontextSwiftSDK.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |spec|
     spec.name                 = 'KontextSwiftSDK'
-    spec.version              = '2.1.0'
+    spec.version              = '2.1.1'
     spec.summary              = 'Kontext.so Swift SDK'
     spec.description          = <<-DESC
     The official Swift SDK for integrating Kontext.so ads into your mobile application.

--- a/Sources/KontextSwiftSDK/Model/Info/SDKInfo.swift
+++ b/Sources/KontextSwiftSDK/Model/Info/SDKInfo.swift
@@ -7,7 +7,7 @@ struct SDKInfo {
     /// SDK name identifier
     static let sdkName = "sdk-swift"
     /// Current SDK version in Major.Minor.Patch format
-    static let sdkVersion = "2.1.0"
+    static let sdkVersion = "2.1.1"
 
     /// Name of the SDK's bundle, should be sdk-swift
     let name: String


### PR DESCRIPTION
## 2.1.1

* Fix crash in `AdScriptMessageHandler` when `WKScriptMessage.body` is not a valid JSON top-level object (e.g. a raw `String` posted by a third-party ad creative). `JSONSerialization.data(withJSONObject:)` was raising an Objective-C `NSException` that Swift `try/catch` could not catch; the bridge now validates with `JSONSerialization.isValidJSONObject` first and throws a catchable `DecodingError` instead.

## Background

The same fix was originally merged as #118 into a branch that also carries the unreleased Open Measurement (OM) SDK work. Since OM SDK isn't ready to ship, this PR cherry-picks #118 onto the 2.1.0 baseline (commit `fbe9131`) so the crash fix can ship as a patch release without dragging OM SDK along with it.

Reproduced in the field on iOS 26.4 with a TikTok-style banner creative that posts string payloads via `window.postMessage`. The bridge then forwarded the raw string into `JSONSerialization.data(withJSONObject:)`, which raised `NSInvalidArgumentException: "Invalid top-level type in JSON write"` — uncatchable in Swift, killing the host app.

## Changes

- `Sources/KontextSwiftSDK/Extensions/Codable+JSON.swift` — add `JSONSerialization.isValidJSONObject` guard before calling `data(withJSONObject:)`. Throws `DecodingError.dataCorrupted` so the existing `do/catch` in `AdScriptMessageHandler.userContentController(_:didReceive:)` logs the bad payload and drops it.
- `Tests/KontextAdsTests/Extensions/CodableJSONTests.swift` — new test file with `decodeFromJSONThrowsForInvalidJSONObject` plus the standard encode/decode/roundtrip coverage from PR #118.
- Version bumps to 2.1.1 in `CHANGELOG.md`, `KontextSwiftSDK.podspec`, `SDKInfo.swift` per `RELEASING.md`.

## Test plan

- [x] `xcodebuild -scheme KontextSwiftSDK -destination 'platform=iOS Simulator,name=iPhone 17' test` — 29/29 pass, including the new `decodeFromJSONThrowsForInvalidJSONObject`
- [x] Run ExampleSwiftUI against a build of this branch and confirm a crashing creative no longer kills the app
- [x] Run ExampleUIKit against a build of this branch and confirm the same
- [ ] After merge: tag `2.1.1`, push tag, `pod trunk push KontextSwiftSDK.podspec --allow-warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)