### PR TITLE
Parse bid.creativeType from nested om block (v4 server wire shape)

### DIFF
--- a/Sources/KontextSwiftSDK/Networking/DTO/BidDTO.swift
+++ b/Sources/KontextSwiftSDK/Networking/DTO/BidDTO.swift
@@ -10,16 +10,25 @@ import KontextKit
 /// Tolerant on optional metadata (`revenue`, `impressionTrigger`,
 /// `creativeType`, `skan`) — unknown enum values or type mismatches
 /// fall back to nil so server-side additions don't break old SDKs.
+///
+/// The v4 ad server emits the OMID creative type on a nested `om` block
+/// (`bids[i].om.creativeType`), not as a top-level field. Decode both
+/// shapes; `toBid()` prefers the nested location and falls back to the
+/// top-level slot for forward-compat. Without the nested-block decode
+/// the SDK silently fails to open OMID sessions in production
+/// (`bid.creativeType` is always nil, which guards the `startOMSession`
+/// call in `Ad.handleAdDoneIframe` / `Ad.handleAdDoneComponentIframe`).
 struct BidDTO: Sendable, Decodable {
     let bidId: UUID
     let code: String
     let revenue: Double?
     let impressionTrigger: ImpressionTrigger?
     let creativeType: OMCreativeType?
+    let om: OMDTO?
     let skan: Skan?
 
     enum CodingKeys: String, CodingKey {
-        case bidId, code, revenue, impressionTrigger, creativeType, skan
+        case bidId, code, revenue, impressionTrigger, creativeType, om, skan
     }
 
     init(from decoder: Decoder) throws {
@@ -29,18 +38,40 @@ struct BidDTO: Sendable, Decodable {
         self.revenue           = try? c.decode(Double.self, forKey: .revenue)
         self.impressionTrigger = try? c.decode(ImpressionTrigger.self, forKey: .impressionTrigger)
         self.creativeType      = try? c.decode(OMCreativeType.self, forKey: .creativeType)
+        self.om                = try? c.decode(OMDTO.self, forKey: .om)
         self.skan              = try? c.decode(Skan.self, forKey: .skan)
     }
 
     /// Maps the wire-format bid into the SDK-internal `Bid` domain type.
+    ///
+    /// Prefers the nested `om.creativeType` over the top-level
+    /// `creativeType` because the v4 server actually emits the nested
+    /// form on the wire; the top-level slot is forward-compat only.
     func toBid() -> Bid {
         Bid(
             bidId: bidId,
             code: code,
             revenue: revenue,
             impressionTrigger: impressionTrigger,
-            creativeType: creativeType,
+            creativeType: om?.creativeType ?? creativeType,
             skan: skan
         )
+    }
+}
+
+/// Nested OM metadata block on a bid. Mirrors the server's
+/// `bids[i].om` object shape. The only field that currently matters
+/// is `creativeType`; the block is kept as a nested object on the wire
+/// so future OM fields can land here without breaking decode.
+struct OMDTO: Sendable, Decodable {
+    let creativeType: OMCreativeType?
+
+    enum CodingKeys: String, CodingKey {
+        case creativeType
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.creativeType = try? c.decode(OMCreativeType.self, forKey: .creativeType)
     }
 }

--- a/Tests/KontextSwiftSDKTests/Networking/DTO/BidDTOTests.swift
+++ b/Tests/KontextSwiftSDKTests/Networking/DTO/BidDTOTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+@testable import KontextSwiftSDK
+import KontextKit
+import Testing
+
+/// Wire-format decoding + domain mapping for `BidDTO`. The v4 server emits
+/// the OMID creative type on a nested `om` block; before this PR `BidDTO`
+/// only read the top-level `creativeType` field, which was always `nil`
+/// in production — silently disabling OMID sessions because
+/// `Ad.handleAdDoneIframe` guards `startOMSession` on `bid.creativeType`.
+struct BidDTOTests {
+
+    private func decode(_ json: String) throws -> BidDTO {
+        let data = json.data(using: .utf8)!
+        return try JSONDecoder().decode(BidDTO.self, from: data)
+    }
+
+    // MARK: - Decoding
+
+    @Test func decodesAllTopLevelFields() throws {
+        let json = """
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd",
+            "revenue": 1.5,
+            "impressionTrigger": "component",
+            "creativeType": "display"
+        }
+        """
+        let bid = try decode(json)
+        #expect(bid.bidId == UUID(uuidString: "11111111-1111-1111-1111-111111111111"))
+        #expect(bid.code == "inlineAd")
+        #expect(bid.revenue == 1.5)
+        #expect(bid.impressionTrigger == .component)
+        #expect(bid.creativeType == .display)
+        #expect(bid.om == nil)
+    }
+
+    @Test func decodesMinimalRequiredFields() throws {
+        let json = """
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd"
+        }
+        """
+        let bid = try decode(json)
+        #expect(bid.revenue == nil)
+        #expect(bid.impressionTrigger == nil)
+        #expect(bid.creativeType == nil)
+        #expect(bid.om == nil)
+    }
+
+    @Test func decodesNestedOmCreativeType() throws {
+        // v4 server wire shape: bids[i].om.creativeType. The nested
+        // OMDTO block is the production source of truth — top-level
+        // `creativeType` is always null on real responses. Without this
+        // decode the SDK silently fails to open OMID sessions because
+        // `Ad.handleAdDoneIframe`'s `bid.creativeType` guard short-circuits.
+        let json = """
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd",
+            "om": { "creativeType": "video" }
+        }
+        """
+        let bid = try decode(json)
+        #expect(bid.om?.creativeType == .video)
+        // Top-level slot stays nil when only the nested form is present —
+        // the mapper prefers the nested location anyway.
+        #expect(bid.creativeType == nil)
+    }
+
+    @Test func nestedOmCreativeTypeIgnoresUnknownValues() throws {
+        // Mirror the existing top-level tolerance: unknown enum values
+        // decode to nil rather than throwing, so future server-side
+        // additions (e.g. "interactive") don't break old SDKs.
+        let json = """
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd",
+            "om": { "creativeType": "interactive" }
+        }
+        """
+        let bid = try decode(json)
+        #expect(bid.om?.creativeType == nil)
+    }
+
+    @Test func decodesBothNestedOmAndTopLevelCreativeType() throws {
+        // Forward-compat: if a future server emits both fields the
+        // decode populates both slots and the mapper's preference rule
+        // decides which one is exposed on the domain Bid.
+        let json = """
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd",
+            "om": { "creativeType": "video" },
+            "creativeType": "display"
+        }
+        """
+        let bid = try decode(json)
+        #expect(bid.om?.creativeType == .video)
+        #expect(bid.creativeType == .display)
+    }
+
+    // MARK: - toBid() preference
+
+    @Test func toBidPrefersNestedOmCreativeTypeOverTopLevel() throws {
+        // The v4 fix lands here. Without this preference rule the
+        // SDK reads the always-nil top-level slot and `Ad.startOMSession`
+        // is never invoked.
+        let bid = try decode("""
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd",
+            "om": { "creativeType": "video" },
+            "creativeType": "display"
+        }
+        """).toBid()
+        #expect(bid.creativeType == .video)
+    }
+
+    @Test func toBidFallsBackToTopLevelCreativeTypeWhenOmIsAbsent() throws {
+        // Forward-compat: if the server stops sending the nested form
+        // the top-level field is still picked up.
+        let bid = try decode("""
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd",
+            "creativeType": "display"
+        }
+        """).toBid()
+        #expect(bid.creativeType == .display)
+    }
+
+    @Test func toBidUsesNestedOmCreativeTypeWhenTopLevelIsAbsent() throws {
+        // The production case as of v4: server sends only the nested form.
+        // This is the case the existing test suite did NOT cover — the SDK
+        // was silently failing to open OMID sessions in production because
+        // toBid() returned nil creativeType.
+        let bid = try decode("""
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd",
+            "om": { "creativeType": "video" }
+        }
+        """).toBid()
+        #expect(bid.creativeType == .video)
+    }
+
+    @Test func toBidReturnsNilCreativeTypeWhenBothAreAbsent() throws {
+        let bid = try decode("""
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd"
+        }
+        """).toBid()
+        #expect(bid.creativeType == nil)
+    }
+
+    @Test func toBidFallsBackToTopLevelWhenNestedOmCreativeTypeIsNull() throws {
+        // Server sends the om block but with a null creativeType inside —
+        // the mapper still falls back to the top-level slot rather than
+        // emitting nil.
+        let bid = try decode("""
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd",
+            "om": { "creativeType": null },
+            "creativeType": "display"
+        }
+        """).toBid()
+        #expect(bid.creativeType == .display)
+    }
+
+    @Test func toBidPassesNonCreativeTypeFieldsThrough() throws {
+        let bid = try decode("""
+        {
+            "bidId": "11111111-1111-1111-1111-111111111111",
+            "code": "inlineAd",
+            "revenue": 2.5,
+            "impressionTrigger": "component",
+            "creativeType": "display"
+        }
+        """).toBid()
+        #expect(bid.bidId == UUID(uuidString: "11111111-1111-1111-1111-111111111111"))
+        #expect(bid.code == "inlineAd")
+        #expect(bid.revenue == 2.5)
+        #expect(bid.impressionTrigger == .component)
+        #expect(bid.creativeType == .display)
+        #expect(bid.skan == nil)
+    }
+}


### PR DESCRIPTION
Port of the same fix that landed on sdk-kotlin (commit 1ff2188 / kontextkit-android 0.0.2). Targets \`feat/v4-migration\` so it lands in PR #123.

## Why

The v4 ad server emits the OMID creative type on a nested \`om\` block (\`bids[i].om.creativeType\`), not as a top-level field. \`BidDTO\` only reads the top-level slot, which is **always nil in production responses**.

That nil propagates through \`toBid()\` to \`bid.creativeType\`, which guards the \`startOMSession\` call in \`Ad.handleAdDoneIframe\` / \`Ad.handleAdDoneComponentIframe\`:

\`\`\`swift
if omSession == nil, let creativeType = bid.creativeType {
    startOMSession(creativeType: creativeType)
}
\`\`\`

→ \`startOMSession\` is never invoked → **OMID is silently broken on iOS**. The bug only surfaces against a real ad-server response; the existing test fixtures all use the (forward-compat) top-level form.

## Changes

\`Sources/KontextSwiftSDK/Networking/DTO/BidDTO.swift\`:
- New nested \`om: OMDTO?\` field on \`BidDTO\`. Decoded tolerantly (\`try?\`) so an unknown nested type doesn't break the response decode.
- New \`OMDTO\` struct mirroring the server's \`bids[i].om\` object shape. Stays a nested block so future OM fields can land there without breaking decode.
- \`toBid()\` now does \`om?.creativeType ?? creativeType\` — prefers the nested form, falls back to the top-level slot for forward-compat.

\`Tests/KontextSwiftSDKTests/Networking/DTO/BidDTOTests.swift\` (new, **11 tests**):
- Decode level: all fields / minimal / nested-only / unknown-nested-tolerated / both-forms-present.
- \`toBid()\` preference: nested preferred when both set; top-level used when nested absent; **nested used when top-level absent (the production case)**; nil when both absent; top-level fallback when nested.creativeType is explicitly null; non-creativeType fields pass through.

## Audit on other recent sdk-kotlin OMID fixes

Walked every dispose / tearDown / OMID call site in \`Ad.swift\` and the WebView layer. iOS doesn't have the Android-specific bugs:

| Android bug | iOS status |
|---|---|
| Compose disposes WebView before sessionFinish → spurious \`notFound\` event | \`tearDown()\` does \`omSession.retire()\` → \`finish()\` → \`onDismissModal?()\` in the right order; WebView is still attached through the OMID flush |
| Modal OMID attaches to inline WebView | iOS uses \`weak var currentWebView\` last-writer-wins, modal's \`AdWebView.init\` reassigns it |
| Sync \`loadUrl("about:blank")\` kills JS context inside 1s flush | iOS doesn't do this anywhere in destroy |
| v4 generation-counter loses preload results | iOS uses \`preloadInstance === preload\` reference check, already correct |
| Video poster MutationObserver misses nested videos | iOS injects no poster script — WKWebView doesn't have the Android 1×1-default-spinner issue |
| Reflective OMID class paths | typed Swift imports, no reflection |

## Deferred (need iOS IAB validator runs)

Two further Android changes might need porting to kontextkit-ios but can't be decided without observing iOS validator output:

- **Display \`Owner.NATIVE\` impressionOwner** + native \`AdEvents.loaded()/impressionOccurred()\`. Eliminates the \`geometryChange { reasons: ["notFound"] }\` event between the last valid geometryChange and sessionFinish on Android. iOS got cert with \`javaScriptOwner\` on 2026-04-28 against v3 — re-cert risk if we change it. Need to run an iOS validator session, watch for the \`notFound\` event on dispose; if absent, leave alone.
- **Video metadata polling** (\`readyState >= 1\` before \`session.start()\`). On Android cold-start the videoEl was \`0×0/hidden\` at OMID measurement time. Whether WKWebView loads metadata fast enough on its own is empirical — run a cold-start video validator session, check impression payload's \`adView.geometry\`; only port if it reports \`0×0\`.

## Test plan

- [x] \`xcodebuild test\` — full suite green
- [x] \`xcodebuild test -only-testing 'KontextSwiftSDKTests/BidDTOTests'\` — 11/11 new tests pass
- [ ] Run iOS IAB validator (display + video, cold start) before deciding on the two deferred kontextkit-ios changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)