### PR TITLE
DEVELOPMENT.md + ExampleSecrets pattern + fix flaky cancel test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ fastlane/test_output
 # Claude Code
 .claude/settings.local.json
 .claude/worktrees/
+
+# Local secrets for the example apps. See ExampleSecrets.swift.example
+# and DEVELOPMENT.md.
+ExampleSecrets.swift

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,196 @@
+# Development
+
+This guide is for contributors working on the Kontext Swift SDK locally. For an end-user integration guide, see the [docs site](https://docs.kontext.so/sdk/v4/swift).
+
+## Prerequisites
+
+- **macOS 14+** with **Xcode 16.0+** (the project targets the iOS 18 SDK)
+- **iOS 14+ Simulator** or a physical device for the example apps. Simulators ship with Xcode; manage them via Xcode → Window → Devices & Simulators, or `xcrun simctl`.
+- **[XcodeGen](https://github.com/yonaskolb/XcodeGen)** for regenerating the example app `.xcodeproj` files from `project.yml`. Install: `brew install xcodegen`.
+- **[SwiftLint](https://github.com/realm/SwiftLint)** for the lint job. Install: `brew install swiftlint`.
+
+Swift 5.9 ships with Xcode 16; nothing extra to install. The SDK itself is a Swift Package — `swift build` won't work on host macOS because the library imports `UIKit`, but the SDK's tests run on the Simulator.
+
+## Repository layout
+
+```
+sdk-swift/
+├── Sources/KontextSwiftSDK/         # public SDK source (entry points, networking, WebView bridge, models)
+├── Tests/KontextSwiftSDKTests/      # XCTest + swift-testing suites
+├── ExampleSwiftUI/                  # SwiftUI demo app (XcodeGen)
+│   ├── project.yml                  # XcodeGen input
+│   └── ExampleSwiftUI/              # app sources
+├── ExampleUIKit/                    # UIKit demo app (XcodeGen)
+│   ├── project.yml
+│   └── ExampleUIKit/
+├── ExampleSecrets.swift.example     # template for the gitignored ExampleSecrets.swift (see "Setting your publisher token")
+├── Package.swift                    # SPM manifest
+├── KontextSwiftSDK.podspec          # CocoaPods manifest (alternative distribution)
+├── .swiftlint.yml                   # SwiftLint rules
+├── CLAUDE.md                        # Claude Code project context
+└── RELEASING.md                     # how to cut a release
+```
+
+## Building & testing the SDK
+
+```bash
+# Build the SDK target
+xcodebuild build \
+  -scheme KontextSwiftSDK \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' \
+  -skipPackagePluginValidation
+
+# Run the full test suite
+xcodebuild test \
+  -scheme KontextSwiftSDK \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' \
+  -skipPackagePluginValidation
+
+# Run a single suite (swift-testing identifier)
+xcodebuild test \
+  -scheme KontextSwiftSDK \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro' \
+  -skipPackagePluginValidation \
+  -only-testing 'KontextSwiftSDKTests/BidDTOTests'
+```
+
+The exact simulator name (`iPhone 17 Pro` here) must exist on your machine. List installed simulators with:
+
+```bash
+xcrun simctl list devices available
+```
+
+## Running the example apps
+
+Two demo apps live in `ExampleSwiftUI/` and `ExampleUIKit/`. Both consume the local SDK via SPM and demonstrate the public v4 API end-to-end.
+
+### Setting your publisher token
+
+The example apps reference `ExampleSecrets.publisherToken` at build time. The file `ExampleSecrets.swift` is **gitignored** — your token never gets committed.
+
+1. Copy the template into place:
+
+   ```bash
+   cp ExampleSecrets.swift.example ExampleSecrets.swift
+   ```
+
+2. Edit `ExampleSecrets.swift` and replace `YOUR_PUBLISHER_TOKEN` with your real publisher token. The `iab-certification` value is the public IAB OMID-certification token — useful when running the example against the OMID validator proxy, but not for ad serving against a real publisher.
+
+3. Build the example app — the token compiles into the binary via `ExampleSecrets.publisherToken`.
+
+If `ExampleSecrets.swift` is missing the Xcode build fails immediately with "No such file or directory" pointing at the missing file. Run the `cp` step above and retry.
+
+### Building & running
+
+Each example has its `.xcodeproj` checked in (regenerated from `project.yml` via XcodeGen — see "Regenerating the Xcode projects" below). Open the project in Xcode and Run, or use the CLI:
+
+```bash
+# SwiftUI demo
+xcodebuild build \
+  -project ExampleSwiftUI/ExampleSwiftUI.xcodeproj \
+  -scheme ExampleSwiftUI \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
+
+# UIKit demo
+xcodebuild build \
+  -project ExampleUIKit/ExampleUIKit.xcodeproj \
+  -scheme ExampleUIKit \
+  -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17 Pro'
+```
+
+Run via Xcode's Run button (⌘R) or `xcrun simctl install` + `xcrun simctl launch`.
+
+### Watching SDK logs
+
+The SDK logs every internal event (preload start/response, bid assignment, ad mount, errors, etc.) to stdout via the publisher's `onDebugEvent` callback. The example apps wire it up to `print("[kontext-debug] ...")`. Stream them live with Xcode's debug console or by tailing the simulator:
+
+```bash
+# Stream the booted simulator's stdout for the example app's bundle id
+xcrun simctl spawn booted log stream \
+  --predicate 'process == "ExampleSwiftUI"' \
+  --style compact
+```
+
+To inspect WKWebView traffic (useful when debugging the iframe bridge):
+
+1. Run the app on the Simulator (Safari Web Inspector requires an unsigned debug build, which Xcode produces by default).
+2. Open Safari → Preferences → Advanced → enable "Show features for web developers".
+3. Safari → Develop → \[Your Simulator] → \[your app] → \[iframe URL]. The iframe DOM, JS console, and network panel are all live.
+
+### Booting a simulator from the CLI
+
+```bash
+# List installed simulators
+xcrun simctl list devices available
+
+# Boot one (replace the ID with one from the list above)
+xcrun simctl boot 'iPhone 17 Pro'
+
+# Open Simulator.app so the UI is visible
+open -a Simulator
+```
+
+## Code style
+
+- **Swift 5.9, iOS 14.0+ deployment target.**
+- **`StrictConcurrency` experimental feature is on** (see `Package.swift`) — anything crossing actor boundaries must be `Sendable`. Treat strict-concurrency warnings as errors; they're the lint signal.
+- **`@MainActor`-isolated** anything that touches UIKit or ATT. Bridges from RN / Flutter hop to MainActor explicitly.
+- **No comments by default** — add one only when the *why* is non-obvious (hidden constraint, subtle invariant, workaround for a specific bug, behaviour that would surprise a reader). Don't reference PRs or tickets in code.
+- **SwiftLint** runs over `Sources/` and `Tests/` per `.swiftlint.yml`. Configuration is intentionally minimal — most rules use SwiftLint defaults.
+
+## Regenerating the Xcode projects
+
+The example app `.xcodeproj` files are generated from each `project.yml` by [XcodeGen](https://github.com/yonaskolb/XcodeGen). Both projects' `.pbxproj` are committed so cloning + opening in Xcode Just Works, but if you change a `project.yml` (e.g. to add a new source file) you have to regenerate:
+
+```bash
+cd ExampleSwiftUI && xcodegen generate
+cd ../ExampleUIKit && xcodegen generate
+```
+
+Commit the regenerated `.pbxproj` alongside the `project.yml` change.
+
+## CI
+
+`.github/workflows/ci.yml` runs two jobs on every push and PR:
+
+- **lint** — `swiftlint lint --strict` and `xcodebuild analyze` on the SDK target
+- **test** — `xcodebuild test` on the SDK target
+
+Both run on `macos-15` with Xcode 16.4 / iPhone 16 / iOS 18.5.
+
+## Testing against the OMID validator
+
+The IAB OMID validator proxy lets you observe the JS-side OMID session events for a running ad. To use it:
+
+1. Set `ExampleSecrets.publisherToken = "iab-certification"` (the public OMID-cert token).
+2. Run the example app on a Simulator with `iPhone 17 Pro` (or whichever device profile the validator expects).
+3. Open https://omid-validator-proxy.fly.dev (or the local validator dashboard if you've deployed one) and connect.
+4. In the chat UI, send a message containing the magic content string `kontextso ad_id:170036` — the server returns an OMID-cert ad whose iframe registers with the validator.
+5. Watch the validator dashboard for the full session lifecycle: `sessionStart`, `geometryChange`, `loaded`, `impression`, video-specific events (`start`, quartiles, `complete`), `sessionFinish`.
+
+Display sessions should produce: `sessionStart → geometryChange(100%) → loaded → impression(pIV: 100) → sessionFinish` with no extraneous events. Any `geometryChange { reasons: ["notFound"] }` between the last valid geometryChange and sessionFinish is a regression.
+
+Video sessions should produce the same prefix plus the full media lifecycle, with the impression payload reporting non-zero `adView.geometry` (the actual video element dimensions, not 0×0).
+
+## Cross-SDK consistency
+
+The Swift SDK is one of three v4 SDKs (alongside [sdk-kotlin](https://github.com/kontextso/sdk-kotlin) and the in-monorepo [sdk-flutter](https://github.com/kontextso/sdk-v4/tree/main/sdk/sdk-flutter) / sdk-react-native). They share a wire protocol and a deliberate file-structure parity: `Configuration.swift` / `Configuration.kt`, `Inbound.swift` / `Inbound.kt`, `Session.swift` / `Session.kt`, etc.
+
+When adding a new type or renaming an existing one, **match the Kotlin counterpart**. If you can't, leave a comment explaining the mismatch.
+
+## KontextKit dependency
+
+The shared iOS primitives — IDFA, ATT, StoreKit, OMID lifecycle, device info, in-app browser — live in [KontextKit](https://github.com/kontextso/kontextkit-ios), distributed via SPM + CocoaPods. The version is pinned in `Package.swift` and `KontextSwiftSDK.podspec`.
+
+For local development against an unreleased KontextKit, point the SPM package at a sibling checkout:
+
+```swift
+// In Package.swift, replace the .package(url: ...) entry with:
+.package(path: "../kontextkit-ios"),
+```
+
+Then revert before merging. (Package-path overrides are not committed — they don't survive consumer SPM resolution.)
+
+## OMID xcframework
+
+KontextKit transitively pulls `OMSDK_Kontextso.xcframework` (the binary OMID SDK from IAB). You do not need to add it to this repo or to your example app — KontextKit's `OMManager` owns the activation and exposes the public surface `sdk-swift` uses.

--- a/ExampleSecrets.swift.example
+++ b/ExampleSecrets.swift.example
@@ -1,0 +1,22 @@
+// Local development override for the example apps (`ExampleSwiftUI`,
+// `ExampleUIKit`).
+//
+// 1. Copy this file to `ExampleSecrets.swift` in the repo root.
+//
+//    cp ExampleSecrets.swift.example ExampleSecrets.swift
+//
+// 2. `ExampleSecrets.swift` is gitignored — your token will not be
+//    committed.
+// 3. Edit the value below in the copy, then rebuild the example app.
+//
+// When `ExampleSecrets.swift` is absent the Xcode project references a
+// missing file and the build fails clearly — copy the example into
+// place first.
+
+enum ExampleSecrets {
+    /// Publisher token for the demo apps. Replace with your real token
+    /// to exercise `/preload` end-to-end. The `iab-certification` value
+    /// is the public IAB OMID certification token — useful for OMID
+    /// validator runs but not for normal ad serving.
+    static let publisherToken = "YOUR_PUBLISHER_TOKEN"
+}

--- a/ExampleSwiftUI/ExampleSwiftUI.xcodeproj/project.pbxproj
+++ b/ExampleSwiftUI/ExampleSwiftUI.xcodeproj/project.pbxproj
@@ -8,11 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		9585F7B61B177514B658A035 /* KontextSwiftSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 66A8707BB35C920A8A2960FC /* KontextSwiftSDK */; };
+		A888FD8CCBAC83ECCE93C09F /* ExampleSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C65E72990ECA7CF22D032A /* ExampleSecrets.swift */; };
 		D7792ECDA75B0060AFF712D4 /* ExampleSwiftUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782B1227EF27DEDFAF18C5AD /* ExampleSwiftUIApp.swift */; };
 		E976652A88D6A772937E34DC /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 234CFF3DEA640C946D066F82 /* ChatView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		11C65E72990ECA7CF22D032A /* ExampleSecrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExampleSecrets.swift; path = ../../ExampleSecrets.swift; sourceTree = "<group>"; };
 		234CFF3DEA640C946D066F82 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		782B1227EF27DEDFAF18C5AD /* ExampleSwiftUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleSwiftUIApp.swift; sourceTree = "<group>"; };
 		9347C940CA5609CA3740B2EE /* ExampleSwiftUI.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ExampleSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -43,6 +45,7 @@
 			isa = PBXGroup;
 			children = (
 				234CFF3DEA640C946D066F82 /* ChatView.swift */,
+				11C65E72990ECA7CF22D032A /* ExampleSecrets.swift */,
 				782B1227EF27DEDFAF18C5AD /* ExampleSwiftUIApp.swift */,
 			);
 			path = ExampleSwiftUI;
@@ -126,6 +129,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E976652A88D6A772937E34DC /* ChatView.swift in Sources */,
+				A888FD8CCBAC83ECCE93C09F /* ExampleSecrets.swift in Sources */,
 				D7792ECDA75B0060AFF712D4 /* ExampleSwiftUIApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ExampleSwiftUI/ExampleSwiftUI/ChatView.swift
+++ b/ExampleSwiftUI/ExampleSwiftUI/ChatView.swift
@@ -18,7 +18,7 @@ struct ChatView: View {
 
     init() {
         let session = KontextAds.createSession(SessionOptions(
-            publisherToken: "nexus-dev",
+            publisherToken: ExampleSecrets.publisherToken,
             userId: UUID().uuidString,
             conversationId: UUID().uuidString,
             enabledPlacementCodes: ["inlineAd"],

--- a/ExampleSwiftUI/project.yml
+++ b/ExampleSwiftUI/project.yml
@@ -15,6 +15,8 @@ targets:
     platform: iOS
     sources:
       - ExampleSwiftUI
+      - path: ../ExampleSecrets.swift
+        group: ExampleSwiftUI
     dependencies:
       - package: KontextSwiftSDK
         product: KontextSwiftSDK

--- a/ExampleUIKit/ExampleUIKit.xcodeproj/project.pbxproj
+++ b/ExampleUIKit/ExampleUIKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		17CF8FBA4C24966457E367E3 /* KontextSwiftSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 61D456EBD7A78259681348CB /* KontextSwiftSDK */; };
+		923308891F750D9544DA4805 /* ExampleSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB243F1206D34C967097D7C /* ExampleSecrets.swift */; };
 		A504CDD15F361A13CA961BD7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6071080EC749207887492B2 /* AppDelegate.swift */; };
 		A7C9B769DFF47E3AA8FADAD2 /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3312CFFDAB67B644847A081E /* ChatViewController.swift */; };
 /* End PBXBuildFile section */
@@ -15,6 +16,7 @@
 /* Begin PBXFileReference section */
 		2DFEFAEF0D89B55F2635A60C /* ExampleUIKit.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = ExampleUIKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3312CFFDAB67B644847A081E /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
+		8EB243F1206D34C967097D7C /* ExampleSecrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExampleSecrets.swift; path = ../../ExampleSecrets.swift; sourceTree = "<group>"; };
 		973B5E538BF5019F30CAEBB9 /* sdk-swift */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "sdk-swift"; path = ..; sourceTree = SOURCE_ROOT; };
 		F6071080EC749207887492B2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -53,6 +55,7 @@
 			children = (
 				F6071080EC749207887492B2 /* AppDelegate.swift */,
 				3312CFFDAB67B644847A081E /* ChatViewController.swift */,
+				8EB243F1206D34C967097D7C /* ExampleSecrets.swift */,
 			);
 			path = ExampleUIKit;
 			sourceTree = "<group>";
@@ -127,6 +130,7 @@
 			files = (
 				A504CDD15F361A13CA961BD7 /* AppDelegate.swift in Sources */,
 				A7C9B769DFF47E3AA8FADAD2 /* ChatViewController.swift in Sources */,
+				923308891F750D9544DA4805 /* ExampleSecrets.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ExampleUIKit/ExampleUIKit/ChatViewController.swift
+++ b/ExampleUIKit/ExampleUIKit/ChatViewController.swift
@@ -29,7 +29,7 @@ final class ChatViewController: UITableViewController {
 
     init() {
         session = KontextAds.createSession(SessionOptions(
-            publisherToken: "nexus-dev",
+            publisherToken: ExampleSecrets.publisherToken,
             userId: UUID().uuidString,
             conversationId: UUID().uuidString,
             enabledPlacementCodes: ["inlineAd"],

--- a/ExampleUIKit/project.yml
+++ b/ExampleUIKit/project.yml
@@ -15,6 +15,8 @@ targets:
     platform: iOS
     sources:
       - ExampleUIKit
+      - path: ../ExampleSecrets.swift
+        group: ExampleUIKit
     dependencies:
       - package: KontextSwiftSDK
         product: KontextSwiftSDK

--- a/Tests/KontextSwiftSDKTests/Networking/DTO/BidDTOTests.swift
+++ b/Tests/KontextSwiftSDKTests/Networking/DTO/BidDTOTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-@testable import KontextSwiftSDK
 import KontextKit
+@testable import KontextSwiftSDK
 import Testing
 
 /// Wire-format decoding + domain mapping for `BidDTO`. The v4 server emits

--- a/Tests/KontextSwiftSDKTests/Networking/PreloadFetchTests.swift
+++ b/Tests/KontextSwiftSDKTests/Networking/PreloadFetchTests.swift
@@ -484,8 +484,12 @@ struct PreloadFetchTests {
 
         // Generous bound — sdk-js aborts in ms, but URLSession task-cancel
         // can take a beat. A real "ignored cancel" would block on the
-        // request timeout (15s+).
-        #expect(elapsed < 2.0, "cancel should abort fast, took \(elapsed)s")
+        // request timeout (15s+). The budget is loose to account for slow
+        // CI runners (GitHub Actions macOS runners regularly see
+        // multi-second URLSession-cancel propagation under load); the
+        // test still catches a genuinely ignored cancel because that
+        // case blocks on the 15s+ request timeout.
+        #expect(elapsed < 10.0, "cancel should abort fast, took \(elapsed)s")
 
         guard case .failure(let reason, let event, let disableSession) = result else {
             Issue.record("Expected failure, got \(result)")


### PR DESCRIPTION
Targets \`feat/v4-migration\` so it lands inside PR #123. Three loosely-related contributor / CI fixes that all block #123 landing cleanly.

## DEVELOPMENT.md (new)

iOS-equivalent of [sdk-kotlin's DEVELOPMENT.md](https://github.com/kontextso/sdk-kotlin/blob/feat/upgrade-to-v4/DEVELOPMENT.md). Covers prerequisites, repo layout, build/test commands, running the example apps from the CLI, the **OMID validator workflow we used during the v4 audit** (iab-certification token + magic content string + expected display/video event lifecycles — this was nowhere in the repo and new contributors would have to re-discover it), Safari Web Inspector setup, XcodeGen regeneration, CI job descriptions, cross-SDK consistency rule, KontextKit dependency notes.

## ExampleSecrets.swift pattern (new)

Both example apps hardcoded \`publisherToken: \"nexus-dev\"\`. Switched to \`publisherToken: ExampleSecrets.publisherToken\` reading from a shared \`ExampleSecrets.swift\` at repo root.

- \`ExampleSecrets.swift.example\` checked in with placeholder (\`YOUR_PUBLISHER_TOKEN\` + setup comments).
- \`ExampleSecrets.swift\` gitignored — missing file makes Xcode build fail with a clear \"No such file or directory\" pointing at the missing source.
- Both \`project.yml\` files reference \`../ExampleSecrets.swift\` as a source.
- Both \`.xcodeproj\` regenerated via \`xcodegen generate\`.

Mirrors sdk-kotlin's \`local.properties.example\` pattern.

## Flaky cancellation test budget

\`PreloadFetchTests.cancelAbortsInFlightRequest\` asserted that \`Preload.cancel()\` aborts an in-flight URLSession task within **2.0 seconds**. GitHub Actions macOS runners regularly take longer than that under load — the sibling RetryTests in the same CI run took **267 seconds each**. Test passes locally but fails on CI.

Bumped the budget to **10 seconds**. Still well under the 15+ second URLSession request timeout, so the test still catches a genuinely ignored cancel — just doesn't false-positive on slow CI. Triggered by [run 25713830669 / job 75499434560](https://github.com/kontextso/sdk-swift/actions/runs/25713830669/job/75499434560?pr=123).

## Drive-by lint fix

Sorted the imports in \`BidDTOTests.swift\` (was caught by \`swiftlint --strict\` after PR #124 merged).

## Test plan

- [x] \`swiftlint lint --strict\` — only pre-existing violations remain; nothing in my new files
- [x] \`xcodebuild test -scheme KontextSwiftSDK\` — full suite green locally
- [x] \`xcodebuild build -project ExampleSwiftUI/ExampleSwiftUI.xcodeproj\` — green
- [x] \`xcodebuild build -project ExampleUIKit/ExampleUIKit.xcodeproj\` — green
- [x] Manually verified: removing \`ExampleSecrets.swift\` from disk → Xcode build fails clearly with \"No such file\" pointing at the missing source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)