### PR TITLE
fix(preload): persist server sessionId from skip / no-fill / error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.1
+
+Fix the server `sessionId` being dropped on skip / no-fill / ads-disabled / error preload responses.
+
+* `Session` now persists the `sessionId` the server returns on skip / no-fill / ads-disabled / error responses, not only on filled ones. Previously the id was captured only from a filled (`.success`) preload, so a session that never filled — `trackOnly`, frequency-capped, or no-fill — sent an empty `sessionId` on every request and the server minted a fresh session each time, resetting per-session pacing / frequency capping / RTB bid cache. `PreloadResult.failure` now carries the `sessionId`, and `Session.applyPreloadResult` stores it; the update is guarded, so a response without a `sessionId` never clears a previously stored one. No public API changes.
+
 ## 4.0.0
 ### Breaking
 Complete API redesign. The `AdsProvider`-centric model from v1–v2 is replaced by a session/ad pattern: `KontextAds.createSession(...)` returns a `Session`, you feed messages via `session.addMessage(...)`, then create one `Ad` per assistant message via `session.createAd(messageId:)`. Render with `InlineAdUIView` (UIKit). See https://docs.kontext.so/sdk/ios for the integration guide.

--- a/KontextSwiftSDK.podspec
+++ b/KontextSwiftSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                 = 'KontextSwiftSDK'
-    spec.version              = '4.0.0'
+    spec.version              = '4.0.1'
     spec.summary              = 'Kontext.so Swift SDK'
     spec.description          = <<-DESC
     The official Swift SDK for integrating Kontext.so ads into your iOS application.

--- a/Sources/KontextSwiftSDK/Model/PreloadResult.swift
+++ b/Sources/KontextSwiftSDK/Model/PreloadResult.swift
@@ -21,5 +21,13 @@ enum PreloadResult: Sendable {
     /// that should be forwarded to the publisher's `onEvent` handler.
     /// `disableSession` indicates the server flagged this session as
     /// permanently disabled and no further preloads should be attempted.
-    case failure(reason: String, event: AdEvent?, disableSession: Bool)
+    ///
+    /// `sessionId` carries the server session id when the response included
+    /// one — skip / no-fill / ads-disabled responses return a sessionId too,
+    /// and `Session` must persist it from any of them. Otherwise a session
+    /// that only ever skips (trackOnly / frequency-capped) never captures a
+    /// sessionId, sends an empty one every request, and the server mints a
+    /// fresh session each time. `nil` for the genuinely empty cases (network
+    /// / decode failure, 204, or a body without one).
+    case failure(reason: String, event: AdEvent?, disableSession: Bool, sessionId: UUID?)
 }

--- a/Sources/KontextSwiftSDK/Networking/Preload.swift
+++ b/Sources/KontextSwiftSDK/Networking/Preload.swift
@@ -103,7 +103,7 @@ final class Preload {
         // Validate before request
         if messages.isEmpty {
             debug(params.config, "no-messages", ["messages": messages])
-            return .failure(reason: "No messages", event: nil, disableSession: false)
+            return .failure(reason: "No messages", event: nil, disableSession: false, sessionId: nil)
         }
 
         isRunning = true
@@ -229,7 +229,8 @@ final class Preload {
             return .failure(
                 reason: "No content",
                 event: .noFill(.init(skipCode: "unfilled_bid")),
-                disableSession: false
+                disableSession: false,
+                sessionId: nil
             )
         }
 
@@ -255,7 +256,8 @@ final class Preload {
             return .failure(
                 reason: "No bids in response",
                 event: .noFill(.init(skipCode: "unfilled_bid")),
-                disableSession: false
+                disableSession: false,
+                sessionId: sessionId
             )
         }
         return .success(bids: bids, sessionId: sessionId)
@@ -269,7 +271,8 @@ final class Preload {
             return .failure(
                 reason: "Session is disabled",
                 event: .error(.init(message: "Session is disabled", errCode: errCode ?? "session_disabled")),
-                disableSession: true
+                disableSession: true,
+                sessionId: jsonResponse.sessionId
             )
         }
 
@@ -277,7 +280,8 @@ final class Preload {
         return .failure(
             reason: "Ad generation skipped",
             event: .error(.init(message: "Ad generation skipped", errCode: errCode ?? "unknown")),
-            disableSession: false
+            disableSession: false,
+            sessionId: jsonResponse.sessionId
         )
     }
 
@@ -286,7 +290,8 @@ final class Preload {
         return .failure(
             reason: "Ad generation skipped",
             event: .noFill(.init(skipCode: jsonResponse.skipCode ?? "unknown")),
-            disableSession: false
+            disableSession: false,
+            sessionId: jsonResponse.sessionId
         )
     }
 
@@ -316,7 +321,7 @@ final class Preload {
 
         if isCancellation {
             debug(config, "cancelled")
-            return .failure(reason: "Cancelled", event: nil, disableSession: false)
+            return .failure(reason: "Cancelled", event: nil, disableSession: false, sessionId: nil)
         }
 
         debug(config, "error-preloading-ads", ["error": error])
@@ -335,7 +340,8 @@ final class Preload {
         return .failure(
             reason: "Error preloading ads",
             event: .error(.init(message: message, errCode: "request_failed")),
-            disableSession: false
+            disableSession: false,
+            sessionId: nil
         )
     }
 }

--- a/Sources/KontextSwiftSDK/SDKInfo.swift
+++ b/Sources/KontextSwiftSDK/SDKInfo.swift
@@ -15,7 +15,7 @@ struct SDKInfo: Sendable {
 
     /// Current SDK version in Major.Minor.Patch format.
     /// Bump on every release; keep in sync with the podspec when one is added.
-    static let sdkVersion = "4.0.0"
+    static let sdkVersion = "4.0.1"
 
     /// SDK identifier sent in the `sdk` field of `/preload` and `/init`.
     static let sdkName = "sdk-swift"

--- a/Sources/KontextSwiftSDK/Session.swift
+++ b/Sources/KontextSwiftSDK/Session.swift
@@ -638,7 +638,15 @@ public final class Session {
 
             updateBids()
 
-        case .failure(_, let event, let disableSession):
+        case .failure(_, let event, let disableSession, let newSessionId):
+            // Persist the server sessionId even on skip / no-fill / ads-disabled
+            // responses. Without this a session that never fills (trackOnly /
+            // frequency-capped) sends an empty sessionId every request and the
+            // server mints a fresh session each time. Guarded — a response
+            // without a sessionId never clears a previously stored one.
+            if let newSessionId {
+                sessionId = newSessionId
+            }
             if disableSession {
                 disabled = true
                 // Ensure publisher always sees ad.error when a preload

--- a/Tests/KontextSwiftSDKTests/Model/PreloadResultTests.swift
+++ b/Tests/KontextSwiftSDKTests/Model/PreloadResultTests.swift
@@ -56,9 +56,9 @@ struct PreloadResultTests {
     // MARK: - .failure
 
     @Test func failureWithReasonOnly() {
-        let result: PreloadResult = .failure(reason: "No fill", event: nil, disableSession: false)
+        let result: PreloadResult = .failure(reason: "No fill", event: nil, disableSession: false, sessionId: nil)
 
-        guard case .failure(let reason, let event, let disable) = result else {
+        guard case .failure(let reason, let event, let disable, _) = result else {
             Issue.record("Expected failure")
             return
         }
@@ -71,9 +71,9 @@ struct PreloadResultTests {
         // Server returned a skip with an event payload — the SDK forwards
         // the event to the publisher's onEvent handler.
         let event: AdEvent = .noFill(.init(skipCode: "frequency_cap"))
-        let result: PreloadResult = .failure(reason: "Skipped", event: event, disableSession: false)
+        let result: PreloadResult = .failure(reason: "Skipped", event: event, disableSession: false, sessionId: nil)
 
-        guard case .failure(_, let extractedEvent, _) = result else {
+        guard case .failure(_, let extractedEvent, _, _) = result else {
             Issue.record("Expected failure")
             return
         }
@@ -83,9 +83,9 @@ struct PreloadResultTests {
     @Test func failureWithDisableSession() {
         // Server permanently disabled the session — the SDK should stop
         // sending preload requests.
-        let result: PreloadResult = .failure(reason: "Publisher disabled", event: nil, disableSession: true)
+        let result: PreloadResult = .failure(reason: "Publisher disabled", event: nil, disableSession: true, sessionId: nil)
 
-        guard case .failure(let reason, _, let disable) = result else {
+        guard case .failure(let reason, _, let disable, _) = result else {
             Issue.record("Expected failure")
             return
         }

--- a/Tests/KontextSwiftSDKTests/Networking/PreloadFetchTests.swift
+++ b/Tests/KontextSwiftSDKTests/Networking/PreloadFetchTests.swift
@@ -255,7 +255,7 @@ struct PreloadFetchTests {
 
         let result = await makePreload().requestAd(params: makeParams(), session: session)
 
-        guard case .failure(let reason, let event, let disableSession) = result else {
+        guard case .failure(let reason, let event, let disableSession, _) = result else {
             Issue.record("Expected failure, got \(result)")
             return
         }
@@ -285,7 +285,7 @@ struct PreloadFetchTests {
 
         let result = await makePreload().requestAd(params: makeParams(), session: session)
 
-        guard case .failure(let reason, let event, let disableSession) = result else {
+        guard case .failure(let reason, let event, let disableSession, _) = result else {
             Issue.record("Expected failure, got \(result)")
             return
         }
@@ -296,6 +296,52 @@ struct PreloadFetchTests {
             return
         }
         #expect(data.skipCode == "no_inventory")
+    }
+
+    @Test func skipFailureCarriesServerSessionId() async {
+        // The server returns a sessionId on skip / ads-disabled responses;
+        // it must reach the failure so Session can persist it.
+        let sessionId = UUID()
+        let body = """
+        {
+          "sessionId": "\(sessionId.uuidString)",
+          "bids": [],
+          "skip": true,
+          "skipCode": "ads_disabled"
+        }
+        """
+        PreloadStubProtocol.reset()
+        PreloadStubProtocol.script = [.ok(body)]
+        let session = makeStubbedSession()
+
+        let result = await makePreload().requestAd(params: makeParams(isDisabled: true), session: session)
+
+        guard case .failure(_, _, _, let returnedSessionId) = result else {
+            Issue.record("Expected failure, got \(result)")
+            return
+        }
+        #expect(returnedSessionId == sessionId)
+    }
+
+    @Test func noFillFailureCarriesServerSessionId() async {
+        let sessionId = UUID()
+        let body = """
+        {
+          "sessionId": "\(sessionId.uuidString)",
+          "bids": []
+        }
+        """
+        PreloadStubProtocol.reset()
+        PreloadStubProtocol.script = [.ok(body)]
+        let session = makeStubbedSession()
+
+        let result = await makePreload().requestAd(params: makeParams(), session: session)
+
+        guard case .failure(_, _, _, let returnedSessionId) = result else {
+            Issue.record("Expected failure, got \(result)")
+            return
+        }
+        #expect(returnedSessionId == sessionId)
     }
 
     // MARK: - Error path (server-side, in 200 body)
@@ -314,7 +360,7 @@ struct PreloadFetchTests {
 
         let result = await makePreload().requestAd(params: makeParams(), session: session)
 
-        guard case .failure(let reason, let event, let disableSession) = result else {
+        guard case .failure(let reason, let event, let disableSession, _) = result else {
             Issue.record("Expected failure, got \(result)")
             return
         }
@@ -341,7 +387,7 @@ struct PreloadFetchTests {
 
         let result = await makePreload().requestAd(params: makeParams(), session: session)
 
-        guard case .failure(let reason, let event, let disableSession) = result else {
+        guard case .failure(let reason, let event, let disableSession, _) = result else {
             Issue.record("Expected failure, got \(result)")
             return
         }
@@ -367,7 +413,7 @@ struct PreloadFetchTests {
 
         let result = await makePreload().requestAd(params: makeParams(), session: session)
 
-        guard case .failure(let reason, let event, let disableSession) = result else {
+        guard case .failure(let reason, let event, let disableSession, _) = result else {
             Issue.record("Expected failure, got \(result)")
             return
         }
@@ -390,7 +436,7 @@ struct PreloadFetchTests {
 
         let result = await makePreload().requestAd(params: makeParams(), session: session)
 
-        guard case .failure(let reason, _, _) = result else {
+        guard case .failure(let reason, _, _, _) = result else {
             Issue.record("Expected failure, got \(result)")
             return
         }
@@ -407,7 +453,7 @@ struct PreloadFetchTests {
 
         let result = await makePreload().requestAd(params: makeParams(), session: session)
 
-        guard case .failure(let reason, _, _) = result else {
+        guard case .failure(let reason, _, _, _) = result else {
             Issue.record("Expected failure, got \(result)")
             return
         }
@@ -423,7 +469,7 @@ struct PreloadFetchTests {
 
         let result = await makePreload().requestAd(params: makeParams(), session: session)
 
-        guard case .failure(let reason, _, _) = result else {
+        guard case .failure(let reason, _, _, _) = result else {
             Issue.record("Expected failure, got \(result)")
             return
         }
@@ -462,7 +508,7 @@ struct PreloadFetchTests {
         // case blocks on the 15s+ request timeout.
         #expect(elapsed < 10.0, "cancel should abort fast, took \(elapsed)s")
 
-        guard case .failure(let reason, let event, let disableSession) = result else {
+        guard case .failure(let reason, let event, let disableSession, _) = result else {
             Issue.record("Expected failure, got \(result)")
             return
         }

--- a/Tests/KontextSwiftSDKTests/Networking/PreloadTests.swift
+++ b/Tests/KontextSwiftSDKTests/Networking/PreloadTests.swift
@@ -82,7 +82,7 @@ struct PreloadTests {
         let preload = Preload(messages: [])
         let result = await preload.requestAd(params: makeParams())
 
-        if case .failure(let reason, _, _) = result {
+        if case .failure(let reason, _, _, _) = result {
             #expect(reason == "No messages")
         } else {
             Issue.record("Expected failure for empty messages")
@@ -96,7 +96,7 @@ struct PreloadTests {
         // Connecting to 0.0.0.0:1 should fail
         let result = await preload.requestAd(params: makeParams())
 
-        if case .failure(let reason, _, _) = result {
+        if case .failure(let reason, _, _, _) = result {
             #expect(reason == "Error preloading ads")
         } else {
             Issue.record("Expected failure for network error")

--- a/Tests/KontextSwiftSDKTests/Networking/RetryTests.swift
+++ b/Tests/KontextSwiftSDKTests/Networking/RetryTests.swift
@@ -47,7 +47,7 @@ struct RetryTests {
         let preload = Preload(messages: messages)
         let result = await preload.requestAd(params: makeParams())
 
-        if case .failure(let reason, _, _) = result {
+        if case .failure(let reason, _, _, _) = result {
             #expect(reason == "Error preloading ads")
         } else {
             Issue.record("Expected failure after retries")

--- a/Tests/KontextSwiftSDKTests/SDKInfoTests.swift
+++ b/Tests/KontextSwiftSDKTests/SDKInfoTests.swift
@@ -8,7 +8,7 @@ struct SDKInfoTests {
         let sdk = SDKInfo.current
         #expect(sdk.name == "sdk-swift")
         #expect(sdk.platform == "ios")
-        #expect(sdk.version == "4.0.0")
+        #expect(sdk.version == "4.0.1")
     }
 
     // MARK: - toDTO()
@@ -28,6 +28,6 @@ struct SDKInfoTests {
 
         #expect(dto.name == "sdk-swift")
         #expect(dto.platform == "ios")
-        #expect(dto.version == "4.0.0")
+        #expect(dto.version == "4.0.1")
     }
 }

--- a/Tests/KontextSwiftSDKTests/SessionTests.swift
+++ b/Tests/KontextSwiftSDKTests/SessionTests.swift
@@ -354,7 +354,8 @@ struct SessionTests {
         session.applyPreloadResult(.failure(
             reason: "test-disable",
             event: nil,
-            disableSession: true
+            disableSession: true,
+            sessionId: nil
         ))
 
         #expect(session.disabled)
@@ -408,12 +409,53 @@ struct SessionTests {
         session.applyPreloadResult(.failure(
             reason: "test-disable",
             event: serverEvent,
-            disableSession: true
+            disableSession: true,
+            sessionId: nil
         ))
 
         #expect(session.disabled)
         #expect(received.values.count == 1)
         #expect(received.values.first == serverEvent)
+    }
+
+    @Test func applyPreloadResultStoresSessionIdFromFailure() {
+        // The server returns a sessionId on skip / no-fill responses; Session
+        // must persist it even though the result is a .failure, so later
+        // preloads reuse it instead of minting a new server session.
+        let session = makeSession()
+        let sid = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+
+        session.applyPreloadResult(.failure(
+            reason: "skip",
+            event: .noFill(.init(skipCode: "ads_disabled")),
+            disableSession: false,
+            sessionId: sid
+        ))
+
+        #expect(session.sessionId == sid)
+    }
+
+    @Test func applyPreloadResultFailureWithoutSessionIdDoesNotClearStoredOne() {
+        // Defensive: a later response that omits a sessionId must not wipe a
+        // previously stored one (guarded `if let` in applyPreloadResult).
+        let session = makeSession()
+        let sid = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+
+        session.applyPreloadResult(.failure(
+            reason: "skip",
+            event: .noFill(.init(skipCode: "ads_disabled")),
+            disableSession: false,
+            sessionId: sid
+        ))
+        #expect(session.sessionId == sid)
+
+        session.applyPreloadResult(.failure(
+            reason: "skip",
+            event: .noFill(.init(skipCode: "ads_disabled")),
+            disableSession: false,
+            sessionId: nil
+        ))
+        #expect(session.sessionId == sid)
     }
 
     // MARK: - emitEvent


### PR DESCRIPTION
## Problem

The ad-server returns a `sessionId` on **skip / no-fill / ads-disabled / error** responses too (not just fills), and when the SDK sends no `sessionId` the server mints a fresh one. But the SDK only ever stored the id from a **filled** (`.success`) response:

- `PreloadResult.failure` carried no `sessionId`, and `Session.applyPreloadResult`'s `.failure` branch never set it.
- `sessionId` was therefore captured only on a fill.

So a `Session` that **never fills** — `trackOnly`, frequency-capped, no-fill — sent an empty `sessionId` on every preload, and the server created a brand-new session each request, resetting per-session state (frequency capping, ad pacing, RTB bid cache).

Mirror of **sdk-kotlin #116**; confirmed in the iOS example with a `trackOnly` seed (the skip's `sessionId` was dropped → next turn sent `nil` → new session), and on the server side.

## Fix

- Add `sessionId: UUID?` to `PreloadResult.failure`.
- `Preload` populates it on the skip (`skipFailure`), no-fill (empty-bids), and error (`errorFailure`) paths — `errorFailure` carries `jsonResponse.sessionId`, since a 200-body error can include both `errCode` and `sessionId`.
- `Session.applyPreloadResult` stores it on `.failure` via a guarded `if let` — **a response without a `sessionId` never clears a previously stored one** (mirrors the `.success` branch).

No public API change.

## Tests

- **Preload (URLProtocol-stubbed):** skip carries the server `sessionId`; no-fill carries it. (Existing skip/no-fill/error pattern matches updated for the new associated value.)
- **Session:** a `sessionId` from a `.failure` is stored; a later `.failure` without one does not clear the stored id (regression guard).
- Existing `.failure` construction/match sites across the suite updated for the new arity.

Full `xcodebuild test` suite green on the iOS simulator.

## Verification (example app, v4.0.1)

`trackOnly` seed → skip returns `…3126…` → **stored**; next two turns **resend `…3126…`** and fill → one stable session. Before the fix the same flow sent `nil` until the first fill and churned through multiple sessions.

## Release

Bumps SDK `4.0.0 → 4.0.1` (`SDKInfo.sdkVersion` + `podspec` + `CHANGELOG`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)