### PR TITLE
chore(example): add mp7rpxwdrx SKAdNetwork identifier

### DIFF
--- a/Example/Example/Info.plist
+++ b/Example/Example/Info.plist
@@ -35,6 +35,10 @@
 			<key>SKAdNetworkIdentifier</key>
 			<string>cstr6suwn9.skadnetwork</string>
 		</dict>
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>mp7rpxwdrx.skadnetwork</string>
+		</dict>
 	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>


### PR DESCRIPTION
Adds the `mp7rpxwdrx.skadnetwork` ad network identifier to the Example app's `SKAdNetworkItems` so SKAdNetwork attribution can be tested against that network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)